### PR TITLE
ImportError “No module named HTMLParser”

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 shodan
-BeautifulSoup
+beautifulsoup4
 requests
 pyfiglet


### PR DESCRIPTION
I changed "BeautifulSoup" to "beautifulsoup4" in requirements and its run correctly. #1